### PR TITLE
Remove redundant note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+_book
+node_modules
+
+
 # Intellij
 ###################
 .idea

--- a/topics/cache/disable.adoc
+++ b/topics/cache/disable.adoc
@@ -25,5 +25,4 @@ Here's what the config looks like initially.
 To disable the cache set the `enabled` field to false for the cache you want to disable.  You must reboot your
 server for this change to take effect.
 
-NOTE: You must also remove the line like `"provider": "default"` from the `realmCache` configuration. Otherwise disabling cache won't work.
 


### PR DESCRIPTION
- Note about removing "provider: default" from realmCache is not needed anymore as 1.9.7 release doesn't have the line with "provider:default" . So just switch "enabled: false" is sufficient to disable cache.