### PR TITLE
Match table of contents name to document name to help searchability

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -32,7 +32,7 @@
  . link:topics/clustering.adoc[Clustering]
  .. link:topics/clustering/recommended.adoc[Recommended Network Architecture]
  .. link:topics/clustering/example.adoc[Cluster Example]
- .. link:topics/clustering/load-balancer.adoc[Setting Up a Load Balancer]
+ .. link:topics/clustering/load-balancer.adoc[Setting Up a Load Balancer or Proxy]
  .. link:topics/clustering/multicast.adoc[Multicast Network Setup]
  .. link:topics/clustering/serialized.adoc[Serialized Cluster Startup]
  .. link:topics/clustering/booting.adoc[Booting the Cluster]


### PR DESCRIPTION
Seems like gitbook would have something to make building table of contents a bit easier. I didn't look at anything regarding git book at all. 

I just missed this document in the gitbook due to the name saying Load Balancing in the ToC I didn't think it would have anything regarding Reverse Proxys inside of it. 