### PR TITLE
KEYCLOAK-4032: Realms cache is not unbounded anymore by default.

### DIFF
--- a/topics/cache/eviction.adoc
+++ b/topics/cache/eviction.adoc
@@ -3,8 +3,9 @@
 
 There are multiple different caches configured for {{book.project.name}}.
 There is a realm cache that holds information about secured applications, general security data, and configuration options.
-This size of this cache is unbounded and does not have a limit on entries.  This might scare you a little bit, but the number of entries
-in this cache is pretty low compared to the user cache.  There is also a user cache that contains user metadata.  It defaults to a maximum of 10000 entries and uses a least recently used eviction strategy.
+There is also a user cache that contains user metadata.  Both caches default to a maximum of 10000 entries and use a least recently used eviction strategy.
+Each of them is also tied to an object revisions cache that controls eviction in a clustered setup.
+This cache is created implicitely and has twice the configured size.
 There are also separate caches for user sessions, offline tokens, and login failures.  These caches are unbounded in size as well.
 
 The eviction policy and max entries for these caches can be configured in the _standalone.xml_, _standalone-ha.xml_, or
@@ -15,9 +16,11 @@ _domain.xml_ depending on your <<fake/../../operating-mode.adoc#_operating-mode,
 ----
 <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
     <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
-        <local-cache name="realms"/>
+        <local-cache name="realms">
+            <eviction max-entries="10000" strategy="LRU"/>
+        </local-cache>
         <local-cache name="users">
-           <eviction strategy="LRU" max-entries="10000"/>
+            <eviction max-entries="10000" strategy="LRU"/>
         </local-cache>
         <local-cache name="sessions"/>
         <local-cache name="offlineSessions"/>
@@ -27,8 +30,8 @@ _domain.xml_ depending on your <<fake/../../operating-mode.adoc#_operating-mode,
            <eviction strategy="LRU" max-entries="100"/>
         </local-cache>
         <local-cache name="keys">
-           <eviction strategy="LRU" max-entries="1000"/>
-           <expiration max-idle="3600000"/>
+            <eviction strategy="LRU" max-entries="1000"/>
+            <expiration max-idle="3600000"/>
         </local-cache>
     </cache-container>
 ----
@@ -40,7 +43,9 @@ _domain.xml_ depending on your <<fake/../../operating-mode.adoc#_operating-mode,
 <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
     <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
         <transport lock-timeout="60000"/>
-        <local-cache name="realms"/>
+        <local-cache name="realms">
+            <eviction max-entries="10000" strategy="LRU"/>
+        </local-cache>
         <local-cache name="users">
             <eviction max-entries="10000" strategy="LRU"/>
         </local-cache>
@@ -56,5 +61,5 @@ _domain.xml_ depending on your <<fake/../../operating-mode.adoc#_operating-mode,
     </cache-container>
 ----
 
-To limit or expand the number of allowed entries simply add, edit, or remove the `eviction` element or the `expiration` element of particular cache
-configuration.
+To limit or expand the number of allowed entries simply add or edit the `eviction` element or the `expiration` element of particular cache
+configuration. 


### PR DESCRIPTION
- Updated configuration examples.
- Adjusted alignment between non-clustered and clustered examples.
- Added mention of the revisions cache.
- Removed the hint about removing an eviction policy as it could affect the implicit revisions cache in a non-expected way.