### PR TITLE
Revert change to use JSON variables to build JBoss EAP doc links

### DIFF
--- a/book-product.json
+++ b/book-product.json
@@ -22,42 +22,37 @@
     "appserver": {
       "name": "JBoss EAP",
       "version": "7.0",
-      "doc_base_url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
-      "develdoc": {
-        "name": "JBoss EAP Development Guide",
-        "link": "/single/development-guide"
-      },
       "admindoc": {
         "name": "JBoss EAP Configuration Guide",
-        "link": "/single/configuration-guide"
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/configuration-guide"
       },
-      "datasource_ref": {
-        "name": "Datasource Management",
-        "link": "/single/configuration-guide/#datasource_management"
+      "datasource": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#datasource_management"
       },
-      "network_ref": {
-        "name": "Network and Port Configuration",
-        "link": "/single/configuration-guide/#network_and_port_configuration"
+      "network": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#network_and_port_configuration"
       },
-      "socket_ref": {
-        "name": "Socket Binding",
-        "link": "/single/configuration-guide/#socket_bindings"
+      "socket": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#network_and_port_configuration"
       },
-      "loadbalancer_ref": {
-        "name": "Configuring High Availability",
-        "link": "/single/configuration-guide/#configuring_high_availability"
+      "loadbalancer": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#configuring_high_availability"
       },
-      "jgroups_ref": {
-        "name": "Cluster Communication with JGroups",
-        "link": "/single/configuration-guide/#cluster_communication_jgroups"
+      "jgroups": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#cluster_communication_jgroups"
       },
-      "caching_ref": {
-        "name": "Infinispan",
-        "link": "/single/configuration-guide/#infinispan"
+      "caching": {
+        "name": "JBoss EAP Configuration Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/configuration-guide/#infinispan"
       },
-      "jpa_ref": {
-        "name": "Hibernate",
-        "link": "/single/development-guide/#hibernate"
+      "jpa": {
+        "name": "JBoss EAP Development Guide",
+        "link": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/7.0/single/development-guide/#hibernate"
       }
     },
     "developerguide": {

--- a/topics/cache.adoc
+++ b/topics/cache.adoc
@@ -15,4 +15,4 @@ but is possibly replicated across the cluster.
 
 This chapter discusses some configuration options for these caches for both clustered a non-clustered deployments.
 
-NOTE:  More advanced configuration of these caches can be found in link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.caching_ref.link}}[{{book.appserver.caching_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+NOTE:  More advanced configuration of these caches can be found in the  link:{{book.appserver.caching.link}}[Infinispan] section of the _{{book.appserver.caching.name}}_.

--- a/topics/clustering.adoc
+++ b/topics/clustering.adoc
@@ -14,4 +14,4 @@ Picking an operation mode and configuring a shared database have been discussed 
 we'll discuss setting up a load balancer and supplying a private network.  We'll also discuss some issues that you need
 to be aware of when booting up a host in the cluster.
 
-NOTE:  It is possible to cluster {{book.project.name}} without IP Multicast, but this topic is beyond the scope of this guide.  For more information, see link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.jgroups_ref.link}}[{{book.appserver.jgroups_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+NOTE:  It is possible to cluster {{book.project.name}} without IP Multicast, but this topic is beyond the scope of this guide.  For more information, see link:{{book.appserver.jgroups.link}}[JGroups] chapter of the _{{book.appserver.jgroups.name}}_.

--- a/topics/clustering/load-balancer.adoc
+++ b/topics/clustering/load-balancer.adoc
@@ -222,4 +222,4 @@ of the master host.
 
 ==== Configuring Other Load Balancers
 
-See link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.loadbalancer_ref.link}}[{{book.appserver.loadbalancer_ref.name}}] in the _{{book.appserver.admindoc.name}}_ for information how to use other software-based load balancers.
+See link:{{book.appserver.loadbalancer.link}}[the load balancing] section in the _{{book.appserver.loadbalancer.name}}_ for information how to use other software-based load balancers.

--- a/topics/clustering/multicast.adoc
+++ b/topics/clustering/multicast.adoc
@@ -31,4 +31,4 @@ You'll have to edit your the _standalone-ha.xml_ or _domain.xml_ sections discus
 
 Things you'll want to configure are the `jboss.bind.address.private` and `jboss.default.multicast.address` as well as the ports of the services on the clustering stack.
 
-NOTE: It is possible to cluster {{book.project.name}} without IP Multicast, but this topic is beyond the scope of this guide. For more information, see link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.jgroups_ref.link}}[{{book.appserver.jgroups_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+NOTE: It is possible to cluster {{book.project.name}} without IP Multicast, but this topic is beyond the scope of this guide. For more information, see link:{{book.appserver.jgroups.link}}[JGroups] in the _{{book.appserver.jgroups.name}}_.

--- a/topics/clustering/troubleshooting.adoc
+++ b/topics/clustering/troubleshooting.adoc
@@ -16,4 +16,4 @@ If for some reason you still need to have firewall enabled on cluster nodes, you
 Default values are UDP port 55200 and multicast port 45688 with multicast address 230.0.0.4.
 Note that you may need more ports opened if you want to enable additional features like diagnostics for your JGroups stack.
 {{book.project.name}} delegates most of the clustering work to Infinispan/JGroups.
-Please consult link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.jgroups_ref.link}}[{{book.appserver.jgroups_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+For more information, see link:{{book.appserver.jgroups.link}}[JGroups] in the _{{book.appserver.jgroups.name}}_.

--- a/topics/config-subsystem/start-cli.adoc
+++ b/topics/config-subsystem/start-cli.adoc
@@ -41,7 +41,7 @@ connect
 
 You may be thinking to yourself, "I didn't enter in any username or password!".  If you run `jboss-cli` on the same machine
 as your running standalone server or domain controller and your account has appropriate file permissions, you do not have
-to setup or enter in a admin username and password.  See the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}]
+to setup or enter in a admin username and password.  See the link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_]
 for more details on how to make things more secure if you are uncomfortable with that setup.
 
 === CLI Embedded Mode

--- a/topics/database.adoc
+++ b/topics/database.adoc
@@ -15,5 +15,5 @@ The top layered technology for persistence is Hibernate JPA.  This is a object t
 Objects to relational data.  Most deployments of {{book.project.name}} will never have to touch the configuration aspects
 of Hibernate, but we will discuss how that is done if you run into that rare circumstance.
 
-NOTE:  Datasource configuration is covered much more thoroughly in link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.datasource_ref.link}}[{{book.appserver.datasource_ref.name}}]
+NOTE:  Datasource configuration is covered much more thoroughly in link:{{book.appserver.datasource.link}}[the datasource configuration chapter]
        in the _{{book.appserver.admindoc.name}}_.

--- a/topics/database/datasource.adoc
+++ b/topics/database/datasource.adoc
@@ -42,5 +42,4 @@ Finally, with PostgreSQL at least, you need to define the database username and 
 may be worried that this is in clear text in the example.  There are methods to obfuscate this, but this is beyond the
 scope of this guide.
 
-NOTE:  For more information about datasource features, see link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.datasource_ref.link}}[{{book.appserver.datasource_ref.name}}]
-       in the _{{book.appserver.admindoc.name}}_.
+NOTE:  For more information about datasource features, see link:{{book.appserver.datasource.link}}[the datasource configuration chapter] in the _{{book.appserver.admindoc.name}}_.

--- a/topics/database/hibernate.adoc
+++ b/topics/database/hibernate.adoc
@@ -54,4 +54,4 @@ globalStatsInterval::
 schema::
   Specify the database schema to use
 
-NOTE:  These configuration switches and more are described in link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.jpa_ref.link}}[{{book.appserver.jpa_ref.name}}] in the _{{book.appserver.develdoc.name}}_.
+NOTE:  These configuration switches and more are described in the link:{{book.appserver.jpa.link}}[_{{book.appserver.jpa.name}}_].

--- a/topics/manage.adoc
+++ b/topics/manage.adoc
@@ -46,5 +46,4 @@ connect
 
 You may be thinking to yourself, "I didn't enter in any username or password!".  If you run `jboss-cli` on the same machine
 as your running standalone server or domain controller and your account has appropriate file permissions, you do not have
-to setup or enter in a admin username and password.  See the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}]
-for more details on how to make things more secure if you are uncomfortable with that setup.
+to setup or enter in a admin username and password.  See the  link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_] for more details on how to make things more secure if you are uncomfortable with that setup.

--- a/topics/network/bind-address.adoc
+++ b/topics/network/bind-address.adoc
@@ -50,4 +50,4 @@ $ domain.sh -Djboss.bind.address=192.168.0.5
 The `-b` is just a shorthand notation for this command.  So, you can either change the bind address value directly in the profile config, or change it on the command line when
 you boot up.
 
-NOTE:  There are many more options available when setting up `interface` definitions. For more information, see link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.network_ref.link}}[{{book.appserver.network_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+NOTE:  There are many more options available when setting up `interface` definitions. For more information, see link:{{book.appserver.network.link}}[the network interface] in the _{{book.appserver.network.name}}_.

--- a/topics/network/ports.adoc
+++ b/topics/network/ports.adoc
@@ -55,4 +55,4 @@ to the `server-group` definitions you can see what `socket-binding-group` is use
     </server-groups>
 ----
 
-NOTE:  There are many more options available when setting up `socket-binding-group` definitions.  For more information, see link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.socket_ref.link}}[{{book.appserver.socket_ref.name}}] in the _{{book.appserver.admindoc.name}}_.
+NOTE:  There are many more options available when setting up `socket-binding-group` definitions.  For more information, see link:{{book.appserver.socket.link}}[the socket binding group] in the _{{book.appserver.socket.name}}_.

--- a/topics/operating-mode.adoc
+++ b/topics/operating-mode.adoc
@@ -9,4 +9,4 @@ your server configurations?  Your choice of operating mode effects how you confi
 
 TIP: The {{book.project.name}} is built on top of the {{book.appserver.name}} Application Server.  This guide will only
      go over the basics for deployment within a specific mode.  If you want specific information on this, a better place
-     to go would be the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}]
+     to go would be the link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_].

--- a/topics/operating-mode/domain.adoc
+++ b/topics/operating-mode/domain.adoc
@@ -10,7 +10,7 @@ a central place to store and publish configuration.  It can be quite complex to 
 This capability is built into the {{book.appserver.name}} Application Server which {{book.project.name}} derives from.
 
 NOTE:  The guide will go over the very basics of domain mode.  Detailed steps on how to set up domain mode in a cluster should be obtained from the
-       link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}].
+       link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_].
 
 Here are some of the basic concepts of running in domain mode.
 
@@ -51,7 +51,7 @@ image:../../{{book.images}}/domain-file.png[]
 
 WARNING: Any changes you make to this file while the domain controller is running will not take effect and may even be overwritten
       by the server.  Instead use the the command line scripting or the web console of {{book.appserver.name}}.  See
-      the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}] for more information.
+      the link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_] for more information.
 
 Let's look at some aspects of this _domain.xml_ file.  The `auth-server-standalone` and `auth-server-clustered` `profile` XML blocks are where you are going to make the bulk of your configuration decisions.
 You'll be configuring things here like network connections, caches, and database connections.

--- a/topics/operating-mode/standalone-ha.adoc
+++ b/topics/operating-mode/standalone-ha.adoc
@@ -22,7 +22,7 @@ image:../../{{book.images}}/standalone-ha-config-file.png[]
 
 WARNING: Any changes you make to this file while the server is running will not take effect and may even be overwritten
       by the server.  Instead use the the command line scripting or the web console of {{book.appserver.name}}.  See
-      the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}] for more information.
+      the link:{{book.appserver.admindoc.link}}[{{_book.appserver.admindoc.name}}_] for more information.
 
 ==== Standalone Clustered Boot Script
 

--- a/topics/operating-mode/standalone.adoc
+++ b/topics/operating-mode/standalone.adoc
@@ -41,4 +41,4 @@ image:../../{{book.images}}/standalone-config-file.png[]
 
 WARNING: Any changes you make to this file while the server is running will not take effect and may even be overwritten
       by the server.  Instead use the the command line scripting or the web console of {{book.appserver.name}}.  See
-      the link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}] for more information.
+      the link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_] for more information.

--- a/topics/overview/recommended-reading.adoc
+++ b/topics/overview/recommended-reading.adoc
@@ -5,4 +5,4 @@
 This guide only covers basics for infrastructure-level configuration.  It is highly recommended that you peruse the documentation
 for {{book.appserver.name}} and its sub projects. Here is the link to the documentation:
 
-* link:{{book.appserver.doc_base_url}}{{book.appserver.version}}{{book.appserver.admindoc.link}}[{{book.appserver.admindoc.name}}]
+* link:{{book.appserver.admindoc.link}}[_{{book.appserver.admindoc.name}}_]


### PR DESCRIPTION
There are better links in some cases, and some of the wording could be improved, but this is now reverted to how it was before. I tested all the JBoss EAP links and they work. I did not test any community builds.